### PR TITLE
feat: add new SQL query engines to tools.md

### DIFF
--- a/tools.md
+++ b/tools.md
@@ -28,6 +28,7 @@ You can use it as a reference to explore and learn about the tools that are wide
   - [Block Storage](#block-storage)
   - [Object Storage](#object-storage)
 - [Query Engine](#query-engine)
+- [In Memory Analytical Databases](#in-memory-analytical-databases)
 - [Data Processing](#data-processing)
   - [Batch](#batch)
   - [Hybrid](#hybrid)
@@ -337,6 +338,9 @@ You can use it as a reference to explore and learn about the tools that are wide
 - [Velox](https://github.com/facebookincubator/velox) - A high-performance, distributed, in-memory data engine for analytics.
 - [Apache Drill](https://github.com/apache/drill) - An open-source, low-latency SQL query engine for big data exploration.
 - [Apache Calcite](https://github.com/apache/calcite) - A dynamic data management framework that provides tools to build SQL engines.
+
+## In Memory Analytical Databases
+
 - [GlareDB](https://github.com/GlareDB/glaredb) - A SQL query engine optimized for working with distributed data across multiple sources.
 - [chDB](https://github.com/chdb-io/chdb) - An embeddable ClickHouse-based analytical database for fast SQL queries.
 - [Apache DataFusion](https://github.com/apache/arrow-datafusion) - A high-performance, extensible query engine built on Apache Arrow.

--- a/tools.md
+++ b/tools.md
@@ -332,11 +332,15 @@ You can use it as a reference to explore and learn about the tools that are wide
 ## Query Engine
 
 - [Presto](https://github.com/prestodb/presto) - An open-source distributed SQL query engine for running interactive analytic queries against data sources of all sizes.
-- [Spark SQL](https://spark.apache.org/sql/) - A module for working with structured data in Spark.]
+- [Spark SQL](https://spark.apache.org/sql/) - A module for working with structured data in Spark.
 - [Trino](https://github.com/trinodb/trino) - A distributed SQL query engine for running interactive analytic queries against data sources of all sizes.
 - [Velox](https://github.com/facebookincubator/velox) - A high-performance, distributed, in-memory data engine for analytics.
 - [Apache Drill](https://github.com/apache/drill) - An open-source, low-latency SQL query engine for big data exploration.
 - [Apache Calcite](https://github.com/apache/calcite) - A dynamic data management framework that provides tools to build SQL engines.
+- [GlareDB](https://github.com/GlareDB/glaredb) - A SQL query engine optimized for working with distributed data across multiple sources.
+- [chDB](https://github.com/chdb-io/chdb) - An embeddable ClickHouse-based analytical database for fast SQL queries.
+- [Apache DataFusion](https://github.com/apache/arrow-datafusion) - A high-performance, extensible query engine built on Apache Arrow.
+- [DuckDB](https://github.com/duckdb/duckdb) - An in-process SQL OLAP database designed for analytics workloads.
 
 ## Data Processing
 


### PR DESCRIPTION
- Added GlareDB, chDB, Apache DataFusion, and DuckDB under Query Engine
- Based on the insights from the blog post: [“The Rise of Single-Node Processing: Challenging the Distributed-First Mindset”](https://practicaldataengineering.substack.com/p/the-rise-of-single-node-processing).